### PR TITLE
Fixes #14: Discovery of jolokiaUrl broken with jquery 2.1.*

### DIFF
--- a/dist/hawtio-jmx.js
+++ b/dist/hawtio-jmx.js
@@ -589,6 +589,10 @@ var JVM;
             function checkNext(url) {
                 JVM.log.debug("trying URL: ", url);
                 $.ajax(url).always(function (data, statusText, jqXHR) {
+                    // for $.ajax().always(), the xhr is flipped on fail
+                    if (statusText !== 'success') {
+                        jqXHR = data;
+                    }
                     if (jqXHR.status === 200) {
                         try {
                             var resp = angular.fromJson(data);

--- a/plugins/jvm/ts/jolokiaService.ts
+++ b/plugins/jvm/ts/jolokiaService.ts
@@ -66,6 +66,10 @@ module JVM {
       function checkNext(url) {
         log.debug("trying URL: ", url);
         $.ajax(url).always((data, statusText, jqXHR) => {
+          // for $.ajax().always(), the xhr is flipped on fail
+          if (statusText !== 'success') {
+            jqXHR = data;
+          }
           if (jqXHR.status === 200) {
             try {
               var resp = angular.fromJson(data);
@@ -100,7 +104,7 @@ module JVM {
   export function getConnectionName(reset = false) {
     if (!Core.isBlank(ConnectionName) && !reset) {
       return ConnectionName;
-    } 
+    }
     ConnectionName = '';
     var search = <any>new URI().search(true);
     if ('con' in window) {
@@ -351,7 +355,7 @@ module JVM {
       };
       windowJolokia = answer;
       // empty jolokia that returns nothing
-      return answer;          
+      return answer;
     }
   }]);
 


### PR DESCRIPTION
- when using $ajax.always(), jquery sends the xhr that failed during a failure as first param.
