### PR TITLE
Allow jolokiaParams to be overridden by $provide() delegation

### DIFF
--- a/dist/hawtio-jmx.js
+++ b/dist/hawtio-jmx.js
@@ -803,7 +803,7 @@ var JVM;
                     beforeSend: getBeforeSend()
                 });
                 var modal = null;
-                jolokiaParams['ajaxError'] = function (xhr, textStatus, error) {
+                jolokiaParams['ajaxError'] = jolokiaParams['ajaxError'] ? jolokiaParams['ajaxError'] : function (xhr, textStatus, error) {
                     if (xhr.status === 401 || xhr.status === 403) {
                         userDetails.username = null;
                         userDetails.password = null;

--- a/plugins/jvm/ts/jolokiaService.ts
+++ b/plugins/jvm/ts/jolokiaService.ts
@@ -283,7 +283,7 @@ module JVM {
       });
 
       var modal = null;
-      jolokiaParams['ajaxError'] = (xhr, textStatus, error) => {
+      jolokiaParams['ajaxError'] = jolokiaParams['ajaxError'] ? jolokiaParams['ajaxError'] : (xhr, textStatus, error) => {
         if (xhr.status === 401 || xhr.status === 403) {
           userDetails.username = null;
           userDetails.password = null;


### PR DESCRIPTION
Fixes #18 

Before clobbering caller's setting of jolokiaParams.ajaxError, do a check if its already there.

Use case:

```

module.config(['$provide', function($provide) {
  $provide.decorator('jolokiaParams', ['$delegate', 'jolokiaStatus', function($delegate, jolokiaStatus) {

    // Override the default ajax handler.
    $delegate.ajaxError = function (xhr, textStatus, error) {
      // My code goes here...
      jolokiaStatus.xhr = xhr;
      // etc.
    };

    return $delegate;
  }]);
```

Angular be awesome at this.
