### PR TITLE
Runtime plugin

### DIFF
--- a/plugins/jvm/ts/discover.ts
+++ b/plugins/jvm/ts/discover.ts
@@ -41,6 +41,7 @@ namespace JVM {
       angular.extend(options, urlObject);
       options.userName = agent.username;
       options.password = agent.password;
+      options.view="runtime/overview";
       connectToServer(localStorage, options);
     }
 

--- a/plugins/jvm/ts/discover.ts
+++ b/plugins/jvm/ts/discover.ts
@@ -41,6 +41,7 @@ namespace JVM {
       angular.extend(options, urlObject);
       options.userName = agent.username;
       options.password = agent.password;
+      // show the overview tab by default to give confirmation to the user that the connection was ok
       options.view="runtime/overview";
       connectToServer(localStorage, options);
     }

--- a/plugins/jvm/ts/local.ts
+++ b/plugins/jvm/ts/local.ts
@@ -65,7 +65,7 @@ namespace JVM {
       // add empty username as we dont need login
       options["userName"] = "";
       options["password"] = "";
-      // connect to root by default as we do not want to show welcome page
+      // show the overview tab by default to give confirmation to the user that the connection was ok
       options["view"] = "runtime/overview";
 
       const con = Core.createConnectToServerOptions(options);

--- a/plugins/jvm/ts/local.ts
+++ b/plugins/jvm/ts/local.ts
@@ -66,7 +66,7 @@ namespace JVM {
       options["userName"] = "";
       options["password"] = "";
       // connect to root by default as we do not want to show welcome page
-      options["view"] = "#/";
+      options["view"] = "runtime/overview";
 
       const con = Core.createConnectToServerOptions(options);
       con.name = "local-" + port;

--- a/plugins/runtime/help/help.md
+++ b/plugins/runtime/help/help.md
@@ -1,0 +1,13 @@
+## Runtime plugin
+
+The runtime plugin presents key information about the JVM.
+
+#### Overview
+
+Contains information about process, host and command line
+
+#### System Properties
+Filterable and sortable list of system properties. Property value can be copied to the clipboard by clicking in a cell.
+
+#### Metrics
+Some key metrics about the running JVM , such as memory , CPU , garbage collections etc.

--- a/plugins/runtime/html/layout.html
+++ b/plugins/runtime/html/layout.html
@@ -1,0 +1,6 @@
+<div class="runtime-nav-main">
+  <div ng-controller="RuntimeLayoutController as $ctrl">
+    <hawtio-tabs tabs="$ctrl.tabs" on-change="$ctrl.goto(tab)"></hawtio-tabs>
+  </div>
+  <div class="contents" ng-view></div>
+</div>

--- a/plugins/runtime/html/metrics.html
+++ b/plugins/runtime/html/metrics.html
@@ -1,0 +1,18 @@
+<div class="runtime-controller"
+	ng-controller="RuntimeMetricsController">
+
+	<div class="row-fluid">
+		<div class="span10">
+			<div class="control-group inline-block pull-right">
+				<input type="text" class="search-query ng-pristine ng-valid"
+					placeholder="Filter..."
+					ng-model="metricsTableConfig.filterOptions.filterText"> <i
+					class="icon-remove clickable" title="Clear filter"
+					ng-click="metricsTableConfig.filterOptions.filterText = ''"></i>
+			</div>
+			<table class="table table-condensed table-striped"
+				hawtio-simple-table="metricsTableConfig"></table>
+		</div>
+	</div>
+</div>
+

--- a/plugins/runtime/html/metrics.html
+++ b/plugins/runtime/html/metrics.html
@@ -1,5 +1,6 @@
 <div class="runtime-controller"
 	ng-controller="RuntimeMetricsController">
+  <h1>Metrics</h1>
 
 	<div class="row-fluid">
 		<div class="span10">

--- a/plugins/runtime/html/metrics.html
+++ b/plugins/runtime/html/metrics.html
@@ -3,15 +3,9 @@
 
 	<div class="row-fluid">
 		<div class="span10">
-			<div class="control-group inline-block pull-right">
-				<input type="text" class="search-query ng-pristine ng-valid"
-					placeholder="Filter..."
-					ng-model="metricsTableConfig.filterOptions.filterText"> <i
-					class="icon-remove clickable" title="Clear filter"
-					ng-click="metricsTableConfig.filterOptions.filterText = ''"></i>
-			</div>
-			<table class="table table-condensed table-striped"
-				hawtio-simple-table="metricsTableConfig"></table>
+      <pf-table-view config="tableConfig" dt-options="tableDtOptions"
+                     colummns="tableColumns" items="metrics"></pf-table-view>
+
 		</div>
 	</div>
 </div>

--- a/plugins/runtime/html/overview.html
+++ b/plugins/runtime/html/overview.html
@@ -1,0 +1,40 @@
+<div class="runtime-controller"
+	ng-controller="RuntimeOverviewController">
+
+	<div class="row-fluid">
+		<div class="span10">
+			<div class="expandable open">
+				<div title="Overview" class="title">
+					<i class="expandable-indicator"></i> Overview
+				</div>
+				<div class="expandable-body well">
+					Running: (pid: <b>{{pid}}</b>) {{runtime.VmName}} -
+					{{runtime.SpecVersion}} ({{runtime.VmVersion}}) by
+					{{runtime.VmVendor}} in <b>{{runtime.SystemProperties['user.name']}}@{{host}}</b>
+					running ({{operatingSystem.Name}} version
+					{{operatingSystem.Version}} with
+					{{operatingSystem.AvailableProcessors}} * {{operatingSystem.Arch}}
+					CPU cores) since <b>{{runtime.StartTime | date: 'yyyy-MM-dd HH:mm:ss' }} (uptime: {{uptime}})</b>
+				</div>
+			</div>
+			<div class="expandable open">
+				<div title="Working directory" class="title">
+					<i class="expandable-indicator"></i> Working directory
+				</div>
+				<div class="expandable-body well" >
+					<a href="file://{{workingDirectory}}" target="_blank">{{workingDirectory}}</a></b>
+				</div>
+			</div>
+			<div class="expandable open">
+				<div title="Command Line" class="title">
+					<i class="expandable-indicator"></i> Command line (simulated)
+				</div>
+				<div class="expandable-body well breakLong" zero-clipboard
+					data-clipboard-text="{{javaPath}} -classpath {{classPath}} {{vmArgs}} {{runtime.SystemProperties['sun.java.command']}}"
+					tooltip="minimal command line (add system properties from below if not specific enough)">
+					{{javaPath}} -classpath {{classPath}} {{vmArgs}} <strong>{{runtime.SystemProperties['sun.java.command']}}</strong>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/plugins/runtime/html/overview.html
+++ b/plugins/runtime/html/overview.html
@@ -1,13 +1,15 @@
 <div class="runtime-controller"
 	ng-controller="RuntimeOverviewController">
+  <h1>Overview</h1>
 
-	<div class="row-fluid">
-		<div class="span10">
-			<div class="expandable open">
-				<div title="Overview" class="title">
-					<i class="expandable-indicator"></i> Overview
-				</div>
-				<div class="expandable-body well">
+  <div class="row-fluid">
+    <div class="span10">
+      <fieldset class="fields-section-pf" id="{{include.id-summary}}">
+        <legend class="fields-section-header-pf">
+          <span class="fa field-section-toggle-pf" ng-class="{'fa-angle-down' : showSummary , 'fa-angle-right' : !showSummary}"></span>
+          <a ng-click="showSummary = !showSummary" class="field-section-toggle-pf">Summary</a>
+        </legend>
+				<div class="form-group well overview-box" ng-hide="!showSummary" id="summary-text" hawtio-clipboard="#summary-text"  data-clipboard-target="#summary-text">
 					Running: (pid: <b>{{pid}}</b>) {{runtime.VmName}} -
 					{{runtime.SpecVersion}} ({{runtime.VmVersion}}) by
 					{{runtime.VmVendor}} in <b>{{runtime.SystemProperties['user.name']}}@{{host}}</b>
@@ -16,25 +18,31 @@
 					{{operatingSystem.AvailableProcessors}} * {{operatingSystem.Arch}}
 					CPU cores) since <b>{{runtime.StartTime | date: 'yyyy-MM-dd HH:mm:ss' }} (uptime: {{uptime}})</b>
 				</div>
-			</div>
-			<div class="expandable open">
-				<div title="Working directory" class="title">
-					<i class="expandable-indicator"></i> Working directory
-				</div>
-				<div class="expandable-body well" >
+      </fieldset>
+      <fieldset class="fields-section-pf" id="wd">
+        <legend class="fields-section-header-pf">
+          <span class="fa field-section-toggle-pf" ng-class="{'fa-angle-down' : showWd , 'fa-angle-right' : !showWd}"></span>
+          <a class="field-section-toggle-pf" ng-click="showWd = !showWd">Working directory</a>
+        </legend>
+				<div class="form-group well overview-box" ng-hide="!showWd" id="wd-text" hawtio-clipboard="#summary-text"  data-clipboard-target="#summary-text">
 					<a href="file://{{workingDirectory}}" target="_blank">{{workingDirectory}}</a></b>
 				</div>
+      </fieldset>
 			</div>
-			<div class="expandable open">
-				<div title="Command Line" class="title">
-					<i class="expandable-indicator"></i> Command line (simulated)
-				</div>
-				<div class="expandable-body well breakLong" zero-clipboard
-					data-clipboard-text="{{javaPath}} -classpath {{classPath}} {{vmArgs}} {{runtime.SystemProperties['sun.java.command']}}"
+
+    <fieldset class="fields-section-pf" id="commandLine">
+      <legend class="fields-section-header-pf">
+        <span class="fa field-section-toggle-pf" ng-class="{'fa-angle-down' : showCmd , 'fa-angle-right' : !showCmd}"></span>
+        <a class="field-section-toggle-pf" ng-click="showCmd = !showCmd">Command line (simulated)</a>
+      </legend>
+				<div class="form-group breakLong well overview-box" ng-hide="!showCmd"
+             id="cmd-text" hawtio-clipboard="#cmd-text"  data-clipboard-target="#cmd-text"
 					tooltip="minimal command line (add system properties from below if not specific enough)">
 					{{javaPath}} -classpath {{classPath}} {{vmArgs}} <strong>{{runtime.SystemProperties['sun.java.command']}}</strong>
 				</div>
+    </fieldset>
 			</div>
 		</div>
 	</div>
 </div>
+

--- a/plugins/runtime/html/systemProperties.html
+++ b/plugins/runtime/html/systemProperties.html
@@ -2,16 +2,11 @@
 	ng-controller="RuntimeSystemPropertiesController">
 
 	<div class="row-fluid">
-		<div class="span10">
-			<div class="control-group inline-block pull-right">
-				<input type="text" class="search-query ng-pristine ng-valid"
-					placeholder="Filter..."
-					ng-model="systemPropertiesTableConfig.filterOptions.filterText">
-				<i class="icon-remove clickable" title="Clear filter"
-					ng-click="systemPropertiesTableConfig.filterOptions.filterText = ''"></i>
-			</div>
-			<table class="table table-condensed table-striped"
-				hawtio-simple-table="systemPropertiesTableConfig"></table>
-		</div>
+    <div>
+      <pf-toolbar config="toolbarConfig">
+      </pf-toolbar>
+      <pf-table-view config="tableConfig" dt-options="tableDtOptions"
+                     colummns="tableColumns" items="filteredProperties"></pf-table-view>
+    </div>
 	</div>
 </div>

--- a/plugins/runtime/html/systemProperties.html
+++ b/plugins/runtime/html/systemProperties.html
@@ -1,0 +1,17 @@
+<div class="runtime-controller"
+	ng-controller="RuntimeSystemPropertiesController">
+
+	<div class="row-fluid">
+		<div class="span10">
+			<div class="control-group inline-block pull-right">
+				<input type="text" class="search-query ng-pristine ng-valid"
+					placeholder="Filter..."
+					ng-model="systemPropertiesTableConfig.filterOptions.filterText">
+				<i class="icon-remove clickable" title="Clear filter"
+					ng-click="systemPropertiesTableConfig.filterOptions.filterText = ''"></i>
+			</div>
+			<table class="table table-condensed table-striped"
+				hawtio-simple-table="systemPropertiesTableConfig"></table>
+		</div>
+	</div>
+</div>

--- a/plugins/runtime/html/systemProperties.html
+++ b/plugins/runtime/html/systemProperties.html
@@ -1,5 +1,6 @@
 <div class="runtime-controller"
 	ng-controller="RuntimeSystemPropertiesController">
+  <h1>System Properties</h1>
 
 	<div class="row-fluid">
     <div>

--- a/plugins/runtime/less/runtime.less
+++ b/plugins/runtime/less/runtime.less
@@ -19,3 +19,12 @@
     padding-right: 20px;
   }
 }
+
+.forceBreakLongLines {
+	word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+.hardWidthLimitM {
+	max-width: 850px;
+}

--- a/plugins/runtime/less/runtime.less
+++ b/plugins/runtime/less/runtime.less
@@ -28,3 +28,7 @@
 .hardWidthLimitM {
 	max-width: 850px;
 }
+
+.overview-box {
+  border: solid black 1px;
+}

--- a/plugins/runtime/less/runtime.less
+++ b/plugins/runtime/less/runtime.less
@@ -1,0 +1,21 @@
+.runtime-nav-main {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: auto;
+
+  .nav-tabs {
+    flex: 0 0 auto;
+    padding-top: 20px;
+    margin-left: 20px;
+    margin-right: 20px;
+  }
+
+  .contents {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    position: relative;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+}

--- a/plugins/runtime/ts/layout.controller.ts
+++ b/plugins/runtime/ts/layout.controller.ts
@@ -1,0 +1,17 @@
+/**
+ * @module Diagnostics
+ */
+namespace Runtime {
+
+
+export function RuntimeLayoutController($location, runtimeService) {
+    'ngInject';
+
+    this.tabs = runtimeService.getTabs();
+
+    this.goto = (tab: Core.HawtioTab) => {
+      $location.path(tab.path);
+    }
+  }
+
+}

--- a/plugins/runtime/ts/metrics.controller.ts
+++ b/plugins/runtime/ts/metrics.controller.ts
@@ -1,0 +1,248 @@
+///<reference path="./runtimeExports.ts"/> 
+module Runtime {
+    
+    export interface Threading {
+        ThreadCount: number;
+        PeakThreadCount: number;
+    }
+
+    export interface ClassLoading {
+        LoadedClassCount: number;
+        TotalLoadedClassCount: number;
+    }
+
+    export interface OperatingSystem {
+        MaxFileDescriptorCount: number;
+        OpenFileDescriptorCount: number;
+        ProcessCpuLoad: number;
+        ProcessCpuTime: number;
+        SystemCpuLoad: number;
+        FreePhysicalMemorySize: number;
+        TotalPhysicalMemorySize: number;
+        TotalSwapSpaceSize: number;
+        FreeSwapSpaceSize: number;
+    }
+
+    export interface SystemProperty {
+        name: string;
+        value: string;
+    }
+
+    export interface Metric {
+        index: number;//to prevent default sorting on names alphabetically
+        name: string;
+        category: string;
+        value: any;
+        referenceValue: any;
+        link: string;
+    }
+
+    export interface MbeanHandler {
+        mbean: string;
+        callback: ( value: any ) => void;
+    }
+
+    export interface MetricsControllerScope extends ng.IScope {
+        metricsTableConfig: any;
+        threading: Threading;
+        operatingSystem: OperatingSystem;
+        heapUsage: MemoryUsage;
+        classLoading: ClassLoading;
+        classPath: string;
+        updaters: { [index: string]: ( any ) => void };
+        metrics: Array<Metric>;
+        garbageCollectors: { [index: string]: GarbageCollector };
+    }
+
+    export interface MemoryUsage {
+        used: number;
+        max: number;
+        init: number;
+        committed: number;
+    }
+
+    interface Memory {
+        HeapMemoryUsage: MemoryUsage;
+    }
+
+    export interface GarbageCollector {
+        Name: string;
+        CollectionCount: number;
+        CollectionTime: number;
+    }
+
+    function metricsTableConfig() {
+        return {
+            selectedItems: [],
+            data: 'metrics',
+            showFilter: true,
+            filterOptions: {
+                filterText: ''
+            },
+            showSelectionCheckbox: false,
+            enableRowClickSelection: true,
+            multiSelect: false,
+            primaryKeyFn: ( entity, idx ) => {
+                return entity.index;
+            },
+            columnDefs: [
+                {
+                    field: 'index',
+                    displayName: '#'
+                },
+                {
+                    field: 'name',
+                    displayName: 'Metric',
+                    resizable: true
+                },
+                {
+                    field: 'category',
+                    displayName: 'Category',
+                    resizable: true,
+                    cellTemplate: '<div class="ngCellText ng-binding" title="row.entity.category"><a href="{{row.entity.link}}">{{row.entity.category}}</a></div>'
+                },
+                {
+                    field: 'value',
+                    displayName: 'Value',
+                    resizable: true,
+                    cellTemplate: '<div class="align-right ngCellText ng-binding" title="row.entity.value">{{row.entity.value}}</div>'
+                },
+                {
+                    field: 'referenceValue',
+                    displayName: '',
+                    resizable: true,
+                    cellTemplate: '<div class="align-right ngCellText ng-binding" title="row.entity.referenceValue">{{row.entity.referenceValue}}</div>'
+                }
+            ]
+        };
+    }
+
+    function deriveMetrics( scope: MetricsControllerScope, filter: ng.IFilterService ) {
+
+        function toPercentage( value: number ):string {
+            return filter( "number" )( value * 100.0, 2 ) + '%';
+        }
+
+        function withSpaceAsThousandSeparator( value: number ):string {
+            var firstString: string = '' + value;
+            var formatted: string = '';
+            for ( var i = 0; i < firstString.length; i++ ) {
+                var character = firstString.charAt( i );
+                if ( ( firstString.length - i ) % 3 == 0 ) {
+                    formatted += ' ';
+                }
+                formatted += character;
+            }
+            return formatted;
+        }
+
+        function separatedAndWithPercent( value: number, referenceValue: number ):string {
+            var result = withSpaceAsThousandSeparator( value );
+            result += ' (';
+            result += toPercentage( 1.0 * value / referenceValue );
+            result += ')';
+            return result;
+        }
+
+        var newMetrics: Array<Metric> = [];
+        var index = 1;
+
+        if ( scope.operatingSystem ) {
+            var osLink = 'jmx/attributes?nid=root-java.lang-OperatingSystem';
+            newMetrics.push( { index: index++, name: 'File descriptors (open/max)', category: 'OS', value: withSpaceAsThousandSeparator( scope.operatingSystem.OpenFileDescriptorCount ), referenceValue: withSpaceAsThousandSeparator( scope.operatingSystem.MaxFileDescriptorCount ), link: osLink });
+            newMetrics.push( { index: index++, name: 'System CPU load', category: 'OS', value: toPercentage( scope.operatingSystem.SystemCpuLoad ), referenceValue: '', link: osLink });
+            newMetrics.push( {
+                index: index++, name: 'Physical memory (free/total)', category: 'OS', link: osLink,
+                value: separatedAndWithPercent( scope.operatingSystem.FreePhysicalMemorySize, scope.operatingSystem.TotalPhysicalMemorySize ),
+                referenceValue: withSpaceAsThousandSeparator( scope.operatingSystem.TotalPhysicalMemorySize )
+            });
+
+            newMetrics.push( {
+                index: index++, name: 'Swap memory space (free/total)', category: 'OS', link: osLink,
+                value: separatedAndWithPercent( scope.operatingSystem.FreeSwapSpaceSize, scope.operatingSystem.TotalSwapSpaceSize ),
+                referenceValue: withSpaceAsThousandSeparator( scope.operatingSystem.TotalSwapSpaceSize )
+            });
+
+            newMetrics.push( {
+                index: index++, name: 'Process CPU (load/time)', category: 'OS', link: osLink,
+                value: toPercentage( scope.operatingSystem.ProcessCpuLoad ),
+                referenceValue: Core.humanizeMilliseconds( scope.operatingSystem.ProcessCpuTime / 1000000 )
+            });
+
+        }
+
+        if ( scope.heapUsage ) {
+            newMetrics.push( {
+                index: index++, name: 'Heap usage (used/max)', category: 'Memory', link: 'diagnostics/heap',
+                value: separatedAndWithPercent( scope.heapUsage.used, scope.heapUsage.max ),
+                referenceValue: withSpaceAsThousandSeparator( scope.heapUsage.max )
+            });
+        }
+
+        if ( scope.threading ) {
+            newMetrics.push( {
+                index: index++, name: 'Thread count (current/peak)', category: 'Threads', link: 'threads',
+                value: scope.threading.ThreadCount, referenceValue: scope.threading.PeakThreadCount
+            });
+        }
+
+        if ( scope.classLoading ) {
+            newMetrics.push( {
+                index: index++, name: 'Classes loaded (current/peak)', category: 'Code', link: 'diagnostics/heap',
+                value: withSpaceAsThousandSeparator( scope.classLoading.LoadedClassCount ),
+                referenceValue: withSpaceAsThousandSeparator( scope.classLoading.TotalLoadedClassCount )
+            });
+        }
+
+        for ( var name in scope.garbageCollectors ) {
+            var garbageCollector: GarbageCollector = scope.garbageCollectors[name];
+            newMetrics.push( {
+                index: index++, name: garbageCollector.Name + ' (collections/time)', category: 'GC', link: 'jmx/attributes?nid=root-java.lang-GarbageCollector',
+                value: garbageCollector.CollectionCount, referenceValue: withSpaceAsThousandSeparator( garbageCollector.CollectionTime ) + " ms"
+            });
+        }
+        return newMetrics;
+    }
+
+    export function RuntimeMetricsController( $scope: MetricsControllerScope, jolokia: Jolokia.IJolokia, workspace: Jmx.Workspace, $filter ) {
+        'ngInject';
+        function render( response ) {
+            var mbean = response.request.mbean;
+            var updater = $scope.updaters[mbean];
+            if ( updater ) {
+                updater( response.value );
+            }
+            if ( mbean = 'java.lang:type=Memory' ) { //the last response
+                $scope.metrics = deriveMetrics( $scope, $filter );
+                Core.$apply( $scope );
+            }
+        }
+        $scope.metricsTableConfig = metricsTableConfig();
+        $scope.updaters = {};
+        $scope.garbageCollectors = {};
+        $scope.updaters['java.lang:type=Threading'] = ( threading: Threading ) => { $scope.threading = threading };
+        $scope.updaters['java.lang:type=OperatingSystem'] = ( operatingSystem: OperatingSystem ) => { $scope.operatingSystem = operatingSystem; };
+        $scope.updaters['java.lang:type=ClassLoading'] = ( classLoading: ClassLoading ) => { $scope.classLoading = classLoading; };
+        //find garbage collectors (if any in JMX tree and set up for metrics calculation)
+        if ( workspace.tree ) {
+            var collectors = workspace.tree.get( 'java.lang' ).get('GarbageCollector');
+            if ( collectors && collectors.children ) {
+                for ( var i = 0; i < collectors.children.length; i++ ) {
+                    var collector = collectors.children[i];
+                    var mbeanKey = '' + collector.domain + ':type=' + collector.entries['type'] + ',name=' + collector.entries['name'];
+                    $scope.updaters[mbeanKey] = ( garbageCollector: GarbageCollector ) => { $scope.garbageCollectors[garbageCollector.Name] = garbageCollector; };
+                }
+            }
+        }
+        $scope.updaters['java.lang:type=Memory'] = ( memory: Memory ) => { $scope.heapUsage = memory.HeapMemoryUsage };
+        var requests = [];
+        for ( var mbean in $scope.updaters ) {
+            requests.push( {
+                type: 'read',
+                mbean: mbean,
+                arguments: []
+            });
+        }
+        Core.register( jolokia, $scope, requests, Core.onSuccess( render ) );
+    }
+}

--- a/plugins/runtime/ts/overview.controller.ts
+++ b/plugins/runtime/ts/overview.controller.ts
@@ -13,6 +13,9 @@ module Runtime {
         operatingSystem: OperatingSystem;
         classPath: string;
         uptime: String;
+        showSummary: boolean;
+        showWd: boolean;
+        showCmd: boolean;
     }
 
     function javaPath( runtime: Runtime ) {
@@ -63,6 +66,9 @@ module Runtime {
             Core.$apply( $scope );
 
         }
+        $scope.showSummary = true;
+        $scope.showWd = true;
+        $scope.showCmd = true;
         Core.register( jolokia, $scope, [{
             type: 'read',
             mbean: runtimeMbean,

--- a/plugins/runtime/ts/overview.controller.ts
+++ b/plugins/runtime/ts/overview.controller.ts
@@ -1,0 +1,77 @@
+/// <reference path="./runtimeExports.ts"/>
+module Runtime {
+
+
+
+    export interface OverviewControllerScope extends ng.IScope {
+        pid: string;
+        host: string;
+        workingDirectory: string;
+        vmArgs: string;
+        javaPath: string;
+        runtime: Runtime;
+        operatingSystem: OperatingSystem;
+        classPath: string;
+        uptime: String;
+    }
+
+    function javaPath( runtime: Runtime ) {
+        var commandLine = '';
+        var javaHome = runtime.SystemProperties['java.home'];
+        if ( javaHome ) {
+            var fileSeparator = runtime.SystemProperties['file.separator'];
+            commandLine += javaHome + fileSeparator + 'bin' + fileSeparator;
+        }
+        commandLine += 'java ';
+        return commandLine;
+    }
+    function vmArgs( runtime: Runtime ):string {
+
+        var commandLine: string = "";
+        for ( var argument in runtime.InputArguments ) {
+            commandLine += escapeSpaces( runtime.InputArguments[argument] ) + ' ';
+        }
+        return commandLine;
+    }
+
+    function escapeSpaces( argument: string ):string {
+        return argument.replace( / /g, '\\ ' );
+    }
+
+
+
+    export function RuntimeOverviewController( $scope: OverviewControllerScope, jolokia: Jolokia.IJolokia, workspace: Jmx.Workspace, $location: ng.ILocationService )  {
+        'ngInject';
+
+      function render( response ) {
+            var mbean: string = response.request.mbean;
+            if ( mbean === runtimeMbean ) {
+                var runtime: Runtime = response.value;
+                $scope.runtime = runtime;
+                var regex = /(\d+)@(.+)/g;
+                var pidAndHost = regex.exec( runtime.Name );
+                $scope.pid = pidAndHost[1];
+                $scope.host = pidAndHost[2];
+                $scope.javaPath = javaPath( runtime );
+                $scope.classPath = escapeSpaces( runtime.ClassPath );
+                $scope.vmArgs = vmArgs( runtime );
+                $scope.workingDirectory = runtime.SystemProperties['user.dir'];
+                $scope.uptime = Core.humanizeMilliseconds( runtime.Uptime );
+            } else if ( mbean === osMbean ) {
+                $scope.operatingSystem = response.value;
+            }
+            Core.$apply( $scope );
+
+        }
+        Core.register( jolokia, $scope, [{
+            type: 'read',
+            mbean: runtimeMbean,
+            arguments: []
+        }, {
+            type: 'read',
+            mbean: osMbean,
+            arguments: []
+        }], Core.onSuccess( render ) );
+ }
+}
+

--- a/plugins/runtime/ts/runtime.config.ts
+++ b/plugins/runtime/ts/runtime.config.ts
@@ -1,0 +1,12 @@
+namespace Runtime {
+
+  export function RuntimeConfig(configManager: Core.ConfigManager) {
+    'ngInject';
+
+    configManager
+      .addRoute('/runtime/overview', {templateUrl: 'plugins/runtime/html/overview.html'})
+      .addRoute('/runtime/systemProperties', {templateUrl: 'plugins/runtime/html/systemProperties.html'})
+      .addRoute('/runtime/metrics', {templateUrl: 'plugins/runtime/html/metrics.html'});
+  }
+
+}

--- a/plugins/runtime/ts/runtime.init.ts
+++ b/plugins/runtime/ts/runtime.init.ts
@@ -1,0 +1,28 @@
+/// <reference path="../../jmx/ts/workspace.ts"/>
+/// <reference path="runtime.service.ts"/>
+
+namespace Runtime {
+
+  export function RuntimeInit($rootScope: ng.IScope, viewRegistry, helpRegistry,
+    workspace: Jmx.Workspace, runtimeService: RuntimeService) {
+    'ngInject';
+    
+    viewRegistry['runtime'] = 'plugins/runtime/html/layout.html';
+
+    helpRegistry.addUserDoc('runtime', 'plugins/runtime/doc/help.md');
+
+    const unsubscribe = $rootScope.$on('jmxTreeUpdated', () => {
+      unsubscribe();
+      const tabs = runtimeService.getTabs();
+      workspace.topLevelTabs.push({
+        id: "runtime",
+        content: "Runtime",
+        title: "Runtie",
+        isValid: () => tabs.length > 0,
+        href: () => tabs[0].path,
+        isActive: (workspace: Jmx.Workspace) => workspace.isLinkActive("diagnostics")
+      });
+    });
+  }
+
+}

--- a/plugins/runtime/ts/runtime.module.ts
+++ b/plugins/runtime/ts/runtime.module.ts
@@ -1,0 +1,26 @@
+/// <reference path="runtime.config.ts"/>
+/// <reference path="overview.controller.ts"/>
+/// <reference path="metrics.controller.ts"/>
+/// <reference path="systemProperties.controller.ts"/>
+/// <reference path="runtime.init.ts"/>
+/// <reference path="layout.controller.ts"/>
+/// <reference path="runtime.service.ts"/>
+
+namespace Runtime {
+
+  let pluginName = 'hawtio-runtime';
+
+  export const log: Logging.Logger = Logger.get(pluginName);
+
+  export const _module = angular
+.module(pluginName, [])
+    .config(RuntimeConfig)
+    .run(RuntimeInit)
+    .controller("RuntimeLayoutController", RuntimeLayoutController)
+    .controller("RuntimeOverviewController", RuntimeOverviewController)
+    .controller("RuntimeSystemPropertiesController", RuntimeSystemPropertiesController)
+    .controller("RuntimeMetricsController", RuntimeMetricsController)
+    .service("runtimeService", RuntimeService);
+
+  hawtioPluginLoader.addModule(pluginName);
+}

--- a/plugins/runtime/ts/runtime.service.ts
+++ b/plugins/runtime/ts/runtime.service.ts
@@ -1,0 +1,28 @@
+/// <reference path="../../jmx/ts/folder.ts"/>
+/// <reference path="../../jmx/ts/workspace.ts"/>
+
+namespace Runtime {
+
+  export class RuntimeService {
+
+    constructor(private workspace: Jmx.Workspace, private configManager: Core.ConfigManager) {
+      'ngInject';
+    }
+
+    getTabs() {
+
+      const tabs = [];
+      if (this.configManager.isRouteEnabled('/runtime/overview')) {
+        tabs.push(new Core.HawtioTab('Overview', '/runtime/overview'));
+      }
+      if (this.configManager.isRouteEnabled('/runtime/systemProperties')) {
+        tabs.push(new Core.HawtioTab('System Properties', '/runtime/systemProperties'));
+      }
+      if (this.configManager.isRouteEnabled('/runtime/metrics')) {
+        tabs.push(new Core.HawtioTab('Metrics', '/runtime/metrics'));
+      }
+      return tabs;
+    }
+  }
+
+}

--- a/plugins/runtime/ts/runtimeExports.ts
+++ b/plugins/runtime/ts/runtimeExports.ts
@@ -1,0 +1,83 @@
+/**
+ * @module Runtime
+ * 
+ * Define shared code for this module
+ * 
+ */
+/// <reference path="../../jmx/ts/workspace.ts"/>
+module Runtime {
+
+    export interface Runtime {
+        VmName: string;
+        SpecVersion: string;
+        VmVersion: string;
+        VmVendor: string;
+        StartTime: string;
+        SystemProperties: { [index: string]: string; };
+        Name: string;
+        InputArguments: Array<string>;
+        ClassPath: string;
+        Uptime: number;
+    }
+
+    export interface OperatingSystem {
+        Name: string;
+        Arch: string;
+        Version: string;
+        AvailableProcessors: string;
+        MaxFileDescriptorCount: number;
+        OpenFileDescriptorCount: number;
+        ProcessCpuLoad: number;
+        ProcessCpuTime: number;
+        SystemCpuLoad: number;
+        SystemLoadAverage: number;
+        FreePhysicalMemorySize: number;
+        TotalPhysicalMemorySize: number;
+        TotalSwapSpaceSize: number;
+        FreeSwapSpaceSize: number;
+    }
+
+
+    export var pluginName = 'runtime';
+    export var contextPath = "app/runtime";
+    export var templatePath = Runtime.contextPath + "/html/";
+    export var runtimeMbean = 'java.lang:type=Runtime';
+    export var osMbean = 'java.lang:type=OperatingSystem';
+
+
+    export function configureScope($scope, $location:ng.ILocationService, workspace:Jmx.Workspace) {
+
+      $scope.isActive = (href) => {
+        var tidy = Core.trimLeading(href, "#");
+        var loc = $location.path();
+        return loc === tidy;
+      };
+
+      $scope.isValid = (link) => {
+        return link && link.isValid(workspace);
+      };
+
+      $scope.breadcrumbs = [
+        {
+          content: 'Overview',
+          title: "Summary of Java process",
+          isValid: (workspace:Jmx.Workspace) => true,
+          href: "#/runtime/overview"
+        },
+        {
+          content: 'System Properties',
+          title: "List system properties",
+          isValid: (workspace:Jmx.Workspace) => true,
+          href: "#/runtime/systemProperties"
+        },
+        {
+          content: 'Metrics',
+          title: "JVM Flags",
+          isValid: (workspace:Jmx.Workspace) => true,
+          href: "#/runtime/metrics"
+        }
+      ];
+    }
+
+};
+

--- a/plugins/runtime/ts/systemProperties.controller.ts
+++ b/plugins/runtime/ts/systemProperties.controller.ts
@@ -1,0 +1,69 @@
+///<reference path="./runtimeExports.ts"/>
+namespace Runtime {
+  export interface SystemProperty {
+        name: string;
+        value: string;
+    }
+    
+    export interface SystemPropertiesControllerScope extends ng.IScope {
+        systemPropertiesTableConfig: any;
+        systemProperties: Array<SystemProperty>;
+    }
+    
+    function systemPropertiesTableConfig() {
+
+        return {
+            selectedItems: [],
+            data: 'systemProperties',
+            showFilter: true,
+            filterOptions: {
+                filterText: ''
+            },
+            showSelectionCheckbox: false,
+            enableRowClickSelection: true,
+            multiSelect: false,
+            primaryKeyFn: ( entity, idx ) => {
+                return entity.name;
+            },
+            columnDefs: [
+                {
+                    field: 'name',
+                    displayName: 'Property',
+                    resizable: true,
+                    cellTemplate: '<div class="forceBreakLongLines hardWidthLimitM" zero-clipboard data-clipboard-text="{{row.entity.name}}">{{row.entity.name}}</div>'
+                },
+                {
+                    field: 'value',
+                    displayName: 'Value',
+                    resizable: true,
+                    cellTemplate: '<div class="forceBreakLongLines hardWidthLimitM" zero-clipboard data-clipboard-text="{{row.entity.value}}">{{row.entity.value}}</div>'
+                }
+            ]
+        };
+
+    }
+
+    export function RuntimeSystemPropertiesController( $scope: SystemPropertiesControllerScope, jolokia: Jolokia.IJolokia, workspace: Jmx.Workspace )  {
+        'ngInject';
+        $scope.systemPropertiesTableConfig = systemPropertiesTableConfig();
+        $scope.systemProperties = [];
+        function render( response )  {
+            var runtime: Runtime = response.value;
+            //system property table
+            $scope.systemProperties = [];
+            for ( var key in runtime.SystemProperties ) {
+                $scope.systemProperties.push( { name: key, value: runtime.SystemProperties[key] });
+            }
+            Core.$apply($scope);
+        }
+        
+        Core.register( jolokia, $scope, {
+            
+                type: 'read',
+                mbean: runtimeMbean,
+                arguments: []
+            }
+        , Core.onSuccess( render ) );
+
+    }
+}

--- a/plugins/runtime/ts/systemProperties.controller.ts
+++ b/plugins/runtime/ts/systemProperties.controller.ts
@@ -12,6 +12,7 @@ namespace Runtime {
     tableConfig: any;
     tableDtOptions: any;
     tableColumns: Array<any>;
+    rowNum: number;
 
 }
 
@@ -20,6 +21,7 @@ namespace Runtime {
     export function RuntimeSystemPropertiesController( $scope: SystemPropertiesControllerScope, jolokia: Jolokia.IJolokia, workspace: Jmx.Workspace )  {
         'ngInject';
         $scope.systemProperties = [];
+        $scope.rowNum = 0;
 
     const FILTER_FUNCTIONS = {
       name: (systemProperties, name) => {
@@ -96,17 +98,22 @@ namespace Runtime {
     };
 
 
+    let row = 0;
     $scope.tableColumns = [
       {
         header: 'Property',
         itemField: 'name',
-        templateFn: value => `<div class="forceBreakLongLines hardWidthLimitM" zero-clipboard data-clipboard-text="${value}">${value}</div>`
+        templateFn: value => {
+          const id="key-" + value.replace('.','-');
+          return '<div class="forceBreakLongLines hardWidthLimitM" id="' + id + ' " hawtio-clipboard="#' + id + '"  data-clipboard-target="#' + id + '">' + value + '</div>';}
       },
 
       {
           itemField: 'value',
           header: 'Value',
-          templateFn: value => `<div class="forceBreakLongLines hardWidthLimitM" zero-clipboard data-clipboard-text="${value}">${value}</div>`
+          templateFn: (value, item) => {
+            const id="key-" + item.name.replace('.','-');
+            return '<div class="forceBreakLongLines hardWidthLimitM" id="' + id + ' " hawtio-clipboard="#' + id + '"  data-clipboard-target="#' + id + '">' + value + '</div>';}
       }
 
     ];


### PR DESCRIPTION
Porting runtime plugin from 1.x to 2.x. 
Code is structured similar to the latest refactoring of the diagnostic plugin. 
Ad hoc connetions will now by default open runtime/overview for a quick confirmation that the connection is to the correct vm, as discussed in #41 

@akieling : Can you see why clipboard support in the system properties table does not work properly? Does it not get picked up when templateFn is used to generate HTML?
And please give some advice on the appearance of the overview tab.
When testing with `yarn start` in the hawtio-jmx project, the patternfly tables for system properties and metrics flicker slightly when rendering on jolokia updates compared to the hawtio 1.x version. 

![image](https://user-images.githubusercontent.com/6298906/35701675-053af2c2-0797-11e8-8e3e-546b8e618077.png)

![image](https://user-images.githubusercontent.com/6298906/35701693-1ede232a-0797-11e8-8e06-e6a5d452a7cf.png)

![image](https://user-images.githubusercontent.com/6298906/35701716-32802ea0-0797-11e8-8f4c-8a5535511746.png)



